### PR TITLE
Fix for undefined method `find_all' for Middleman::Sitemap::ResourceL…

### DIFF
--- a/lib/middleman-sitemap/extension.rb
+++ b/lib/middleman-sitemap/extension.rb
@@ -100,7 +100,7 @@ class Sitemap < ::Middleman::Extension
   private
 
   def get_pages
-    app.sitemap.resources.find_all { |p| p.ext == ".html" && !p.data.ignore }
+    app.sitemap.resources.to_a.find_all { |p| p.ext == ".html" && !p.data.ignore }
   end
 
 end


### PR DESCRIPTION
Started occurring in Middleman versions greater than v5.0.0.rc1. Fix should be backwards compatible